### PR TITLE
fix #9 and #10: replacing whole line not adding ports anymore

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -43,7 +43,7 @@ elif [ "$#" == "0" ];then
     echo "Using default port: 80"
   else
     echo "Using specified port: ${SERVER_PORT}"
-    sed -i -e "s/listen 80/listen ${SERVER_PORT}/" /etc/nginx/conf.d/nuget.conf
+    sed -i -e "s/listen.*/listen ${SERVER_PORT};/" /etc/nginx/conf.d/nuget.conf
   fi
   
   # Set Worker_Processes


### PR DESCRIPTION
Changing `sed`-command in `docker-entrypoint` to replace whole line `listen` in `/etc/nginx/conf.d/nuget.conf`

Prior this PR only "listen 80" with replaced: adding ports for each run.